### PR TITLE
Fix WP_Http example

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ curl --user admin:password http://example.com/wp-json/
 ```php
 $args = array(
 	'headers' => array(
-		'Authentication' => base64_encode( $username . ':' . $password ),
+		'Authorization' => 'Basic ' . base64_encode( $username . ':' . $password ),
 	),
 );
 ```


### PR DESCRIPTION
I spent some time debugging what's wrong until I figured out. Props @johnbillion for [working code](https://johnblackbourn.com/wordpress-http-api-basicauth).
