### PR TITLE
 you can use basic auth AND be logged into the browser

### DIFF
--- a/basic-auth.php
+++ b/basic-auth.php
@@ -44,10 +44,15 @@ function json_basic_auth_handler( $user ) {
 	}
 
 	$wp_json_basic_auth_error = true;
-
+	//if we found a user, remove regular cookie filters because
+	//they're just going to overwrite what we've found
+	if( $user->ID ){
+		remove_filter( 'determine_current_user', 'wp_validate_auth_cookie' );
+		remove_filter( 'determine_current_user', 'wp_validate_logged_in_cookie', 20 );
+	}
 	return $user->ID;
 }
-add_filter( 'determine_current_user', 'json_basic_auth_handler', 20 );
+add_filter( 'determine_current_user', 'json_basic_auth_handler', 5 );
 
 function json_basic_auth_error( $error ) {
 	// Passthrough other errors


### PR DESCRIPTION
addresses #12 in WP-API/Basic-Auth. Just required that the basic-auth take a stab at finding the current user, and if it does find the current user, then it we shouldn't have the cookie method try finding the current user separately (where it would overwrite what we've found).
I've been using this while logged into my browser and using basic auth.