### PR TITLE
Fix basic auth

### DIFF
--- a/basic-auth.php
+++ b/basic-auth.php
@@ -13,6 +13,11 @@ function json_basic_auth_handler( $user ) {
 
 	$wp_json_basic_auth_error = null;
 
+	// Skip authentication for non-api requests
+	if (false === strpos($_SERVER['REQUEST_URI'], 'wp-json')) {
+		return $user;
+	}
+
 	// Don't authenticate twice
 	if ( ! empty( $user ) ) {
 		return $user;

--- a/basic-auth.php
+++ b/basic-auth.php
@@ -20,7 +20,9 @@ function json_basic_auth_handler( $user ) {
 
 	// Check that we're trying to authenticate
 	if ( !isset( $_SERVER['PHP_AUTH_USER'] ) ) {
-		return $user;
+		header('WWW-Authenticate: Basic realm="Authentication needed');
+		header('HTTP/1.0 401 Unauthorized');
+		exit(0);
 	}
 
 	$username = $_SERVER['PHP_AUTH_USER'];
@@ -39,8 +41,9 @@ function json_basic_auth_handler( $user ) {
 	add_filter( 'determine_current_user', 'json_basic_auth_handler', 20 );
 
 	if ( is_wp_error( $user ) ) {
-		$wp_json_basic_auth_error = $user;
-		return null;
+		header('WWW-Authenticate: Basic realm="Authentication needed');
+		header('HTTP/1.0 401 Unauthorized');
+		exit(0);
 	}
 
 	$wp_json_basic_auth_error = true;

--- a/basic-auth.php
+++ b/basic-auth.php
@@ -20,7 +20,7 @@ function json_basic_auth_handler( $user ) {
 
 	// Check that we're trying to authenticate
 	if ( !isset( $_SERVER['PHP_AUTH_USER'] ) ) {
-		header('WWW-Authenticate: Basic realm="Authentication needed');
+		header('WWW-Authenticate: Basic realm="Authentication needed"');
 		header('HTTP/1.0 401 Unauthorized');
 		exit(0);
 	}
@@ -41,7 +41,7 @@ function json_basic_auth_handler( $user ) {
 	add_filter( 'determine_current_user', 'json_basic_auth_handler', 20 );
 
 	if ( is_wp_error( $user ) ) {
-		header('WWW-Authenticate: Basic realm="Authentication needed');
+		header('WWW-Authenticate: Basic realm="Authentication needed"');
 		header('HTTP/1.0 401 Unauthorized');
 		exit(0);
 	}


### PR DESCRIPTION
1) Basic auth doesn't work by direct url in browser (try url like http://wp.lo/wp-json in browser)
2) Basic auth doesn't work for wp api v2 (https://github.com/WP-API/WP-API) in cases:
- curl -i --user user:pass http://wp.lo/wp-json/ 
- curl -i --user not_exists_user:pass http://wp.lo/wp-json/ 
- curl -i http://wp.lo/wp-json/