### PR TITLE
The filter json_authentication_errors obsolete

### DIFF
--- a/basic-auth.php
+++ b/basic-auth.php
@@ -59,4 +59,4 @@ function json_basic_auth_error( $error ) {
 
 	return $wp_json_basic_auth_error;
 }
-add_filter( 'json_authentication_errors', 'json_basic_auth_error' );
+add_filter( 'rest_authentication_errors', 'json_basic_auth_error' );


### PR DESCRIPTION
The filter json_authentication_errors is changed to rest_authentication_errors in WP-API 2.0-beta4.
