### PR TITLE
if bad username and login are provided while using wp api v2, this co…

### DIFF
--- a/basic-auth.php
+++ b/basic-auth.php
@@ -60,3 +60,4 @@ function json_basic_auth_error( $error ) {
 	return $wp_json_basic_auth_error;
 }
 add_filter( 'json_authentication_errors', 'json_basic_auth_error' );
+add_filter( 'rest_authentication_errors', 'json_basic_auth_error' );


### PR DESCRIPTION
…mmit makes it so it also shows an error like it did with wp api v1.
Because currently if you're using this plugin with WP API v2, it mostly works. Except if you provide a bad username and password combination, there is no error message like there was working with wp api v1. This can be troublesome if, for example, logged in admins can see all users, whereas someone who's not logged in can only see a subset. 
