### PR TITLE
Apply suggested fix on issue 9

### DIFF
--- a/basic-auth.php
+++ b/basic-auth.php
@@ -33,10 +33,12 @@ function json_basic_auth_handler( $user ) {
 	 * filter during authentication.
 	 */
 	remove_filter( 'determine_current_user', 'json_basic_auth_handler', 20 );
+	remove_filter( 'authenticate', 'wp_authenticate_spam_check', 99 );
 
 	$user = wp_authenticate( $username, $password );
 
 	add_filter( 'determine_current_user', 'json_basic_auth_handler', 20 );
+	add_filter( 'authenticate', 'wp_authenticate_spam_check', 99 );
 
 	if ( is_wp_error( $user ) ) {
 		$wp_json_basic_auth_error = $user;


### PR DESCRIPTION
applies the fix mentioned on https://github.com/WP-API/Basic-Auth/issues/9. I dont think we need to check for multisite because wp_authenticate_spam_check itself does that check