### PR TITLE
Bugfix: #27 #33 #45 Avoid wp_authenticate's errors

### DIFF
--- a/basic-auth.php
+++ b/basic-auth.php
@@ -34,7 +34,19 @@ function json_basic_auth_handler( $user ) {
 	 */
 	remove_filter( 'determine_current_user', 'json_basic_auth_handler', 20 );
 
-	$user = wp_authenticate( $username, $password );
+	$user = get_user_by('login', $username);
+
+	if ( !$user ) {
+		$user = get_user_by('email', $username);
+	}
+
+	if ( !$user ) {
+		return null;
+	}
+
+	if ( ! wp_check_password( $password, $user->user_pass, $user->ID ) ) {
+		return null;
+	}
 
 	add_filter( 'determine_current_user', 'json_basic_auth_handler', 20 );
 


### PR DESCRIPTION
Sometimes, with an incorrect username and password (or using email address rather than username, which made `wp_authenticate_username_password` error) when `$user = wp_authenticate( $username, $password );` errored, it would call `$wp_rewrite->get_page_permastruct();` before `$wp_rewrite` was initialized, returning a 500 server error. In my case, this would happen when I enabled the SkyVerge WooCommerce Print Invoices/Packing Lists plugin.