### PR TITLE
Package should require `composer/installers`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,8 @@
 {
 	"name" : "wp-api/basic-auth",
 	"description" : "Basic Authentication handler for the JSON API, used for development and debugging purposes",
-	"type" : "wordpress-plugin"
+	"type" : "wordpress-plugin",
+	"require": {
+		"composer/installers": "~1.0"
+	}
 }


### PR DESCRIPTION
From Composer's documentation (https://getcomposer.org/doc/faqs/how-do-i-install-a-package-to-a-custom-path-for-my-framework.md#how-do-i-install-a-package-to-a-custom-path-for-my-framework-):

> If you are a package author and want your package installed to a custom directory, simply require `composer/installers` and set the appropriate `type`.